### PR TITLE
Replaced curly braces with square brackets.

### DIFF
--- a/src/UTF8.php
+++ b/src/UTF8.php
@@ -2901,15 +2901,15 @@ class UTF8
 		switch (strlen($char))
 		{
 			case 1 : return $cache[$char] = ord($char);
-			case 2 : return $cache[$char] = (ord($char{1}) & 63) |
-											((ord($char{0}) & 31) << 6);
-			case 3 : return $cache[$char] = (ord($char{2}) & 63) |
-											((ord($char{1}) & 63) << 6) |
-											((ord($char{0}) & 15) << 12);
-			case 4 : return $cache[$char] = (ord($char{3}) & 63) |
-											((ord($char{2}) & 63) << 6) |
-											((ord($char{1}) & 63) << 12) |
-											((ord($char{0}) & 7)  << 18);
+			case 2 : return $cache[$char] = (ord($char[1]) & 63) |
+											((ord($char[0]) & 31) << 6);
+			case 3 : return $cache[$char] = (ord($char[2]) & 63) |
+											((ord($char[1]) & 63) << 6) |
+											((ord($char[0]) & 15) << 12);
+			case 4 : return $cache[$char] = (ord($char[3]) & 63) |
+											((ord($char[2]) & 63) << 6) |
+											((ord($char[1]) & 63) << 12) |
+											((ord($char[0]) & 7)  << 18);
 			default :
 				trigger_error('Character 0x' . bin2hex($char) . ' is not UTF-8!', E_USER_WARNING);
 				return false;


### PR DESCRIPTION
In php 7.4 curly braces for accessing in string offsets has been deprecated.